### PR TITLE
Refactor pagination and selection to emphasize primitive values, both as state and props.

### DIFF
--- a/src/core_plugins/kibana/public/visualize/listing/visualize_landing_page_table.js
+++ b/src/core_plugins/kibana/public/visualize/listing/visualize_landing_page_table.js
@@ -2,10 +2,11 @@ import React from 'react';
 
 import { VisualizeConstants } from '../visualize_constants';
 import { VisualizeItemPrompt } from './visualize_item_prompt';
-import { SelectedIds } from 'ui/saved_object_table/selected_ids';
-import { Pager } from 'ui/pager/pager';
-import { PagerActions } from 'ui/pager/pager_actions';
-import { ItemSelectionActions } from 'ui/saved_object_table/item_selection_actions';
+import {
+  areAllItemsSelected,
+  toggleItem,
+  toggleAll,
+} from 'ui/saved_object_table/item_selection_actions';
 import { sortItems, getFlippedSortOrder } from 'ui/saved_object_table/sort_items';
 import { TITLE_COLUMN_ID } from 'ui/saved_object_table/get_title_column';
 import { getCheckBoxColumn } from 'ui/saved_object_table/get_checkbox_column';
@@ -21,6 +22,34 @@ import {
   LandingPageToolBarFooter
 } from 'ui_framework/components';
 
+class Pager {
+  constructor(itemsPerPage) {
+    this.itemsPerPage = itemsPerPage;
+  }
+
+  canPagePrevious(currentPage) {
+    return currentPage > 0;
+  }
+
+  canPageNext(itemsCount, currentPage) {
+    const pagesCount = this.getPagesCount(itemsCount);
+    return currentPage < pagesCount - 1;
+  }
+
+  getItemsOnPage(items, currentPage) {
+    const startIndex = currentPage * this.itemsPerPage;
+    const endIndex = startIndex + this.itemsPerPage;
+    return items.filter((item, index) => (
+      index >= startIndex
+      && index < endIndex
+    ));
+  }
+
+  getPagesCount(itemsCount) {
+    return Math.ceil(itemsCount / this.itemsPerPage);
+  }
+}
+
 export class VisualizeLandingPageTable extends React.Component {
   constructor(props) {
     super(props);
@@ -30,8 +59,11 @@ export class VisualizeLandingPageTable extends React.Component {
       items: [],
       sortedColumn: undefined,
       sortOrder: SortOrder.ASC,
-      selectedIds: new SelectedIds()
+      selectedIds: [],
+      currentPage: 0,
     };
+
+    this.pager = new Pager(2);
   }
 
   componentDidMount() {
@@ -42,11 +74,13 @@ export class VisualizeLandingPageTable extends React.Component {
     const PAGE_SIZE = 3;
     this.props.fetch(newFilter).then((results) => {
       const items = results.hits;
+      const pagesCount = this.pager.getPagesCount(items.length);
+
       this.setState({
         items,
         isFetchingItems: false,
-        pager: new Pager(items.length, PAGE_SIZE, 1),
-        selectedIds: new SelectedIds()
+        currentPage: Math.min(this.state.currentPage, pagesCount - 1),
+        selectedIds: [],
       });
     });
   };
@@ -63,27 +97,27 @@ export class VisualizeLandingPageTable extends React.Component {
     }
 
     const sortedItems = sortItems(items, sortedColumn, sortOrder);
-    ItemSelectionActions.deselectAll(selectedIds);
+
     this.setState({
       sortedColumn,
       sortOrder,
-      selectedIds,
+      selectedIds: [],
       items: sortedItems
     });
   };
 
   turnToNextPage = () => {
-    const { pager, selectedIds } = this.state;
-    ItemSelectionActions.deselectAll(selectedIds);
-    PagerActions.nextPage(pager);
-    this.setState({ pager, selectedIds });
+    this.setState({
+      currentPage: this.state.currentPage + 1,
+      selectedIds: [],
+    });
   };
 
   turnToPreviousPage = () => {
-    const { pager, selectedIds } = this.state;
-    ItemSelectionActions.deselectAll(selectedIds);
-    PagerActions.previousPage(pager);
-    this.setState({ pager, selectedIds });
+    this.setState({
+      currentPage: this.state.currentPage - 1,
+      selectedIds: [],
+    });
   };
 
   onSortByTitle = () => {
@@ -95,15 +129,22 @@ export class VisualizeLandingPageTable extends React.Component {
   };
 
   onToggleItem = (item) => {
-    const selectedIds = ItemSelectionActions.toggleItem(this.state.selectedIds, item);
-    this.setState({ selectedIds });
+    this.setState({
+      selectedIds: toggleItem(this.state.selectedIds, item.id),
+    });
   };
 
   onToggleAll = () => {
-    const pageOfItems = PagerActions.calculateItemsOnPage(this.state.pager, this.state.items);
-    const selectedIds = ItemSelectionActions.toggleAll(this.state.selectedIds, pageOfItems);
-    this.setState({ selectedIds });
+    const pageOfItems = this.pager.getItemsOnPage(this.state.items, this.state.currentPage);
+    const pageOfItemIds = pageOfItems.map(item => item.id);
+    this.setState({
+      selectedIds: toggleAll(this.state.selectedIds, pageOfItemIds),
+    });
   };
+
+  hasPreviousPage = () => this.pager.canPagePrevious(this.state.currentPage);
+
+  hasNextPage = () => this.pager.canPageNext(this.state.items.length, this.state.currentPage);
 
   getEditUrlForItem = (item) => {
     return this.props.kbnUrl.eval(`#${VisualizeConstants.EDIT_PATH}/{{id}}`, { id: item.id });
@@ -122,9 +163,10 @@ export class VisualizeLandingPageTable extends React.Component {
   }
 
   getAreAllItemsSelected() {
-    const { selectedIds, items, pager } = this.state;
-    const pageOfItems = PagerActions.calculateItemsOnPage(pager, items);
-    return selectedIds.areAllItemsSelected(pageOfItems);
+    const { selectedIds, items, currentPage } = this.state;
+    const pageOfItems = this.pager.getItemsOnPage(items, currentPage);
+    const pageOfItemIds = pageOfItems.map(item => item.id);
+    return areAllItemsSelected(selectedIds, pageOfItemIds);
   }
 
   getVisualizeColumns() {
@@ -139,7 +181,7 @@ export class VisualizeLandingPageTable extends React.Component {
   onDelete = () => {
     const { deleteItems } = this.props;
     const { selectedIds, filter } = this.state;
-    deleteItems(selectedIds.selectedIds).then((didDelete) => {
+    deleteItems(selectedIds).then((didDelete) => {
       if (didDelete) {
         this.onFilter(filter);
       }
@@ -147,15 +189,15 @@ export class VisualizeLandingPageTable extends React.Component {
   };
 
   getActionButtons() {
-    return this.state.selectedIds.getSelectedItemsCount() > 0
+    return this.state.selectedIds.length > 0
       ? <DeleteButton onClick={this.onDelete} />
       : <CreateButtonLink href={'#' + VisualizeConstants.WIZARD_STEP_1_PAGE_PATH} />;
   }
 
   getTableContents() {
-    const { isFetchingItems, pager, items } = this.state;
+    const { isFetchingItems, currentPage, items } = this.state;
     if (isFetchingItems) return null;
-    const pageOfItems = PagerActions.calculateItemsOnPage(pager, items);
+    const pageOfItems = this.pager.getItemsOnPage(items, currentPage);
     const columns = this.getVisualizeColumns();
 
     return pageOfItems.length > 0
@@ -170,7 +212,11 @@ export class VisualizeLandingPageTable extends React.Component {
       <LandingPageToolBar
         filter={filter}
         onFilter={this.onFilter}
-        pagerState={pager}
+        startNumber={0}
+        endNumber={0}
+        totalItems={10}
+        hasPreviousPage={this.hasPreviousPage}
+        hasNextPage={this.hasNextPage}
         onNextPage={this.turnToNextPage}
         onPreviousPage={this.turnToPreviousPage}
         actionButtons={this.getActionButtons()}/>
@@ -178,10 +224,14 @@ export class VisualizeLandingPageTable extends React.Component {
         this.getTableContents()
       }
       <LandingPageToolBarFooter
-        pagerState={pager}
+        startNumber={0}
+        endNumber={0}
+        totalItems={10}
+        hasPreviousPage={this.hasPreviousPage}
+        hasNextPage={this.hasNextPage}
         onNextPage={this.turnToNextPage}
         onPreviousPage={this.turnToPreviousPage}
-        selectedItemsCount={selectedIds.getSelectedItemsCount()}
+        selectedItemsCount={selectedIds.length}
       />
     </div>;
   }

--- a/src/ui/public/saved_object_table/get_checkbox_column.js
+++ b/src/ui/public/saved_object_table/get_checkbox_column.js
@@ -13,11 +13,10 @@ export function getCheckBoxColumn(allItemsAreSelected, selectedIds, onToggleItem
         isChecked={allItemsAreSelected} />;
     },
     getRowCell: (item) => {
-      function toggle() { onToggleItem(item); }
       return <CheckBoxTableCell
         key={item.id + CHECKBOX_COLUMN_ID}
-        onClick={toggle}
-        isChecked={selectedIds.isItemSelected(item)}/>;
+        onClick={onToggleItem.bind(null, item)}
+        isChecked={selectedIds.filter(id => id === item.id).length > 0}/>;
     },
     isSortable: false
   };

--- a/src/ui/public/saved_object_table/item_selection_actions.js
+++ b/src/ui/public/saved_object_table/item_selection_actions.js
@@ -1,41 +1,22 @@
-export class ItemSelectionActions {
-  static deselectAll(selectedIds) {
-    selectedIds.selectedIds.splice(0, selectedIds.selectedIds.length);
+export function areAllItemsSelected(selectedIds, itemIds) {
+  return itemIds.every(id => selectedIds.indexOf(id) !== -1);
+}
+
+export function toggleItem(selectedIds, itemId) {
+  const itemIndex = selectedIds.indexOf(itemId);
+  if (itemIndex === -1) {
+    return selectedIds.concat(itemId);
   }
 
-  static selectAll(selectedIds, items) {
-    this.deselectAll(selectedIds);
-    items.forEach(item => this.selectItem(selectedIds, item));
+  const copy = selectedIds.slice(0);
+  copy.splice(itemIndex, 1);
+  return copy;
+}
+
+export function toggleAll(selectedIds, itemIds) {
+  if (areAllItemsSelected(selectedIds, itemIds)) {
+    return [];
   }
 
-  static toggleItem(selectedIds, item) {
-    if (selectedIds.isItemSelected(item)) {
-      this.deselectItem(selectedIds, item);
-    } else {
-      this.selectItem(selectedIds, item);
-    }
-    return selectedIds;
-  }
-
-  static toggleAll(selectedIds, items) {
-    if (selectedIds.areAllItemsSelected(items)) {
-      this.deselectAll(selectedIds);
-    } else {
-      this.selectAll(selectedIds, items);
-    }
-    return selectedIds;
-  }
-
-  static selectItem(selectedIds, item) {
-    if (!selectedIds.isItemSelected(item)) {
-      selectedIds.selectedIds.push(item.id);
-    }
-  }
-
-  static deselectItem(selectedIds, item) {
-    if (selectedIds.isItemSelected(item)) {
-      const index = selectedIds.indexOf(item);
-      selectedIds.selectedIds.splice(index, 1);
-    }
-  }
+  return itemIds.slice(0);
 }

--- a/ui_framework/components/table/landing_page_table/landing_page_tool_bar.js
+++ b/ui_framework/components/table/landing_page_table/landing_page_tool_bar.js
@@ -8,19 +8,28 @@ import {
 export function LandingPageToolBar({
     filter,
     onFilter,
-    pagerState,
+    hasPreviousPage,
+    hasNextPage,
     onNextPage,
     onPreviousPage,
-    actionButtons }) {
+    actionButtons,
+    startNumber,
+    endNumber,
+    totalItems,
+}) {
   const toolBarSections = [
     <KuiToolBarSearchBox filter={filter} onFilter={onFilter}/>,
-    actionButtons
+    actionButtons,
+    <KuiToolBarPager
+      startNumber={startNumber}
+      endNumber={endNumber}
+      totalItems={totalItems}
+      hasPreviousPage={hasPreviousPage}
+      hasNextPage={hasNextPage}
+      onNextPage={onNextPage}
+      onPreviousPage={onPreviousPage}
+    />,
   ];
-
-  if (pagerState) {
-    toolBarSections.push(
-      <KuiToolBarPager pagerState={pagerState} onNextPage={onNextPage} onPreviousPage={onPreviousPage}/>);
-  }
 
   return <KuiSectionedToolBar sections={toolBarSections} />;
 }
@@ -28,8 +37,12 @@ export function LandingPageToolBar({
 LandingPageToolBar.propTypes = {
   filter: React.PropTypes.string,
   onFilter: React.PropTypes.func.isRequired,
-  actionButtons: React.PropTypes.node.isRequired,
-  pagerState: React.PropTypes.any,
+  actionButtons: React.PropTypes.node,
+  hasPreviousPage: React.PropTypes.func,
+  hasNextPage: React.PropTypes.func,
   onNextPage: React.PropTypes.func,
-  onPreviousPage: React.PropTypes.func
+  onPreviousPage: React.PropTypes.func,
+  startNumber: React.PropTypes.number,
+  endNumber: React.PropTypes.number,
+  totalItems: React.PropTypes.number,
 };

--- a/ui_framework/components/tool_bar/kui_tool_bar_pager.js
+++ b/ui_framework/components/tool_bar/kui_tool_bar_pager.js
@@ -3,15 +3,15 @@ import React from 'react';
 import { KuiToolBarPagerText } from './kui_tool_bar_pager_text';
 import { KuiToolBarPagerButtons } from './kui_tool_bar_pager_buttons';
 
-export function KuiToolBarPager({ pagerState, onNextPage, onPreviousPage }) {
+export function KuiToolBarPager({ startNumber, endNumber, totalItems, hasPreviousPage, hasNextPage, onNextPage, onPreviousPage }) {
   return <div>
       <KuiToolBarPagerText
-        start={pagerState.startNumber}
-        end={pagerState.endNumber}
-        count={pagerState.totalItems} />
+        start={startNumber}
+        end={endNumber}
+        count={totalItems} />
       <KuiToolBarPagerButtons
-        hasNext={pagerState.hasNextPage}
-        hasPrevious={pagerState.hasPreviousPage}
+        hasNext={hasNextPage()}
+        hasPrevious={hasPreviousPage()}
         onNext={onNextPage}
         onPrevious={onPreviousPage}
       />
@@ -19,7 +19,11 @@ export function KuiToolBarPager({ pagerState, onNextPage, onPreviousPage }) {
 }
 
 KuiToolBarPager.propTypes = {
-  pagerState: React.PropTypes.any.isRequired,
+  startNumber: React.PropTypes.number,
+  endNumber: React.PropTypes.number,
+  totalItems: React.PropTypes.number,
+  hasPreviousPage: React.PropTypes.func.isRequired,
+  hasNextPage: React.PropTypes.func.isRequired,
   onNextPage: React.PropTypes.func.isRequired,
   onPreviousPage: React.PropTypes.func.isRequired
 };

--- a/ui_framework/dist/ui_framework.css
+++ b/ui_framework/dist/ui_framework.css
@@ -1404,6 +1404,7 @@ body {
   text-align: right; }
 
 .kuiTableSortIcon {
+  margin-left: 5px;
   pointer-events: none; }
 
 .kuiTableRow:hover .kuiTableRowHoverReveal {
@@ -1464,6 +1465,9 @@ body {
   .kuiTableRowCell--checkBox .kuiTableRowCell__liner {
     overflow: visible;
     /* 3 */ }
+
+.kuiTableHeaderCell__sortable {
+  cursor: pointer; }
 
 .kuiTabs {
   display: -webkit-box;


### PR DESCRIPTION
@Stacey-Gammon Based on https://github.com/elastic/kibana/pull/10434, I wanted to try out a couple ideas and see what you and @weltenwort thought.

Instead of assigning instances of `Pager` and `SelectedIds` to the state object, I tried to reserve that object for primitive values only. In this case, `currentPage` (number) and `selectedIds` (array).

Then I tried to create pure functional helpers for reasoning and manipulating this state. I created a new `Pager` class (which needs to be extracted) and refactored `ItemSelectionActions` to export pure functions to support selection behavior. I was also able to remove the dependency on `PagerActions`.

The ideas I want to focus on are:

* **Emphasizing primitives makes code easier to follow.** If our data consists of primitive values, then it's easier to create pure functions for operating on them. They're explicit, so the code communicates its meaning without requiring you to learn an abstraction.
* **Pure functions are easier to understand.** I don't to think about side effects or mutated state. When invoking a pure function, all I have to think about is what goes in and what comes out.
* **I think passing props multiple times down the component tree is a code smell.** I'd like to hear what @kjbekkelund thinks about this and what kinds of solutions they used on the Cloud team. Personally, I think that this is a sign that we should be using composition more and passing props less.

**Edit:** I just did a second stage of exploration which builds on this one (https://github.com/cjcenizal/kibana/pull/16)