### PR TITLE
Tweaks to #11003

### DIFF
--- a/src/core_plugins/kibana/index.js
+++ b/src/core_plugins/kibana/index.js
@@ -86,7 +86,7 @@ module.exports = function (kibana) {
           id: 'kibana:dashboard',
           title: 'Dashboard',
           order: -1001,
-          url: `${kbnBaseUrl}#/dashboard/list`,
+          url: `${kbnBaseUrl}#/dashboards`,
           subUrlBase: `${kbnBaseUrl}#/dashboard`,
           description: 'compose visualizations for much win',
           icon: 'plugins/kibana/assets/dashboard.svg',

--- a/src/core_plugins/kibana/index.js
+++ b/src/core_plugins/kibana/index.js
@@ -87,6 +87,7 @@ module.exports = function (kibana) {
           title: 'Dashboard',
           order: -1001,
           url: `${kbnBaseUrl}#/dashboard/list`,
+          subUrlBase: `${kbnBaseUrl}#/dashboard`,
           description: 'compose visualizations for much win',
           icon: 'plugins/kibana/assets/dashboard.svg',
         }, {

--- a/src/core_plugins/kibana/public/dashboard/dashboard.html
+++ b/src/core_plugins/kibana/public/dashboard/dashboard.html
@@ -9,7 +9,7 @@
       >
         <div class="kuiLocalBreadcrumbs" data-test-subj="breadcrumbs">
           <div class="kuiLocalBreadcrumb">
-            <a class=kuiLocalBreadcrumb__link" href="{{landingPageUrl()}}">Dashboard</a>
+            <a class="kuiLocalBreadcrumb__link" href="{{landingPageUrl()}}">Dashboard</a>
           </div>
           <div class="kuiLocalBreadcrumb">
             {{ getDashTitle() }}

--- a/src/core_plugins/kibana/public/dashboard/dashboard.js
+++ b/src/core_plugins/kibana/public/dashboard/dashboard.js
@@ -15,7 +15,7 @@ import dashboardTemplate from 'plugins/kibana/dashboard/dashboard.html';
 import FilterBarQueryFilterProvider from 'ui/filter_bar/query_filter';
 import DocTitleProvider from 'ui/doc_title';
 import { getTopNavConfig } from './top_nav/get_top_nav_config';
-import { DashboardConstants } from './dashboard_constants';
+import { DashboardConstants, createDashboardEditUrl } from './dashboard_constants';
 import { VisualizeConstants } from 'plugins/kibana/visualize/visualize_constants';
 import UtilsBrushEventProvider from 'ui/utils/brush_event';
 import FilterBarFilterBarClickHandlerProvider from 'ui/filter_bar/filter_bar_click_handler';
@@ -42,7 +42,7 @@ uiRoutes
       }
     }
   })
-  .when(`${DashboardConstants.DASHBOARD_EDIT_PATH}/:id`, {
+  .when(createDashboardEditUrl(':id'), {
     template: dashboardTemplate,
     resolve: {
       dash: function (savedDashboards, Notifier, $route, $location, courier) {
@@ -193,10 +193,7 @@ app.directive('dashboardApp', function (Notifier, courier, AppState, timefilter,
 
         function revertChangesAndExitEditMode() {
           dashboardState.resetState();
-          const refreshUrl = dash.id ?
-            `${DashboardConstants.DASHBOARD_EDIT_PATH}/{{id}}` : DashboardConstants.CREATE_NEW_DASHBOARD_URL;
-          const refreshUrlOptions = dash.id ? { id: dash.id } : {};
-          kbnUrl.change(refreshUrl, refreshUrlOptions);
+          kbnUrl.change(dash.id ? createDashboardEditUrl(dash.id) : DashboardConstants.CREATE_NEW_DASHBOARD_URL);
           // This is only necessary for new dashboards, which will default to Edit mode.
           updateViewMode(DashboardViewMode.VIEW);
 
@@ -232,9 +229,7 @@ app.directive('dashboardApp', function (Notifier, courier, AppState, timefilter,
           if (id) {
             notify.info(`Saved Dashboard as "${dash.title}"`);
             if (dash.id !== $routeParams.id) {
-              kbnUrl.change(
-                `${DashboardConstants.DASHBOARD_EDIT_PATH}/{{id}}`,
-                { id: dash.id });
+              kbnUrl.change(createDashboardEditUrl(dash.id));
             } else {
               docTitle.change(dash.lastSavedTitle);
               updateViewMode(DashboardViewMode.VIEW);

--- a/src/core_plugins/kibana/public/dashboard/dashboard_constants.js
+++ b/src/core_plugins/kibana/public/dashboard/dashboard_constants.js
@@ -1,11 +1,15 @@
+import { encodeQueryComponent } from '../../../../utils';
 
 export const DashboardConstants = {
   ADD_VISUALIZATION_TO_DASHBOARD_MODE_PARAM: 'addToDashboard',
   NEW_VISUALIZATION_ID_PARAM: 'addVisualization',
-  LANDING_PAGE_PATH: '/dashboard/list',
+  LANDING_PAGE_PATH: '/dashboards',
   // NOTE, the following two urls have to have LANDING_PAGE_PATH as their sub url for
   // the chrome nav links to work correctly (eg. so navigating away from an opened dashboard, and back to
   // the dashboard app, will reopen the dashboard, not show the landing page.
-  CREATE_NEW_DASHBOARD_URL: '/dashboard/list/create',
-  DASHBOARD_EDIT_PATH: '/dashboard/list/edit'
+  CREATE_NEW_DASHBOARD_URL: '/dashboard',
 };
+
+export function createDashboardEditUrl(id) {
+  return `/dashboard/${encodeQueryComponent(id)}`;
+}

--- a/src/core_plugins/kibana/public/dashboard/index.js
+++ b/src/core_plugins/kibana/public/dashboard/index.js
@@ -15,17 +15,8 @@ uiRoutes
   .defaults(/dashboard/, {
     requireDefaultIndex: true
   })
-  .when('/dashboard', {
-    // For BWC, preserve unsaved dashboard links (i.e. links with state data and no ID) prior to v5.3
-    redirectTo: DashboardConstants.CREATE_NEW_DASHBOARD_URL
-  })
   .when(DashboardConstants.LANDING_PAGE_PATH, {
     template: dashboardListingTemplate,
     controller: DashboardListingController,
     controllerAs: 'listingController'
-  })
-  .when('/dashboard/:id', {
-    // For BWC, preserve saved dashboard links prior to v5.3
-    redirectTo: `${DashboardConstants.DASHBOARD_EDIT_PATH}/:id`
   });
-

--- a/src/core_plugins/kibana/public/dashboard/listing/dashboard_listing.js
+++ b/src/core_plugins/kibana/public/dashboard/listing/dashboard_listing.js
@@ -2,7 +2,7 @@ import SavedObjectRegistryProvider from 'ui/saved_objects/saved_object_registry'
 import 'ui/pager_control';
 import 'ui/pager';
 import _ from 'lodash';
-import { DashboardConstants } from '../dashboard_constants';
+import { DashboardConstants, createDashboardEditUrl } from '../dashboard_constants';
 
 export function DashboardListingController($injector, $scope) {
   const $filter = $injector.get('$filter');
@@ -146,7 +146,7 @@ export function DashboardListingController($injector, $scope) {
   };
 
   this.getUrlForItem = function getUrlForItem(item) {
-    return `#${DashboardConstants.DASHBOARD_EDIT_PATH}/${item.id}`;
+    return `#${createDashboardEditUrl(item.id)}`;
   };
 
   this.getCreateDashboardHref = function getCreateDashboardHref() {

--- a/src/ui/public/chrome/api/nav.js
+++ b/src/ui/public/chrome/api/nav.js
@@ -1,5 +1,5 @@
 import { parse, format } from 'url';
-import { startsWith, isString } from 'lodash';
+import { isString } from 'lodash';
 
 export default function (chrome, internals) {
   chrome.getNavLinks = function () {
@@ -110,7 +110,7 @@ export default function (chrome, internals) {
     const { appId, globalState: newGlobalState } = decodeKibanaUrl(url);
 
     for (const link of internals.nav) {
-      link.active = startsWith(url, link.url);
+      link.active = url.startsWith(link.subUrlBase);
       if (link.active) {
         setLastUrl(link, url);
         continue;
@@ -124,11 +124,16 @@ export default function (chrome, internals) {
     }
   };
 
-  internals.nav.forEach(link => {
+  function relativeToAbsolute(url) {
     // convert all link urls to absolute urls
     const a = document.createElement('a');
-    a.setAttribute('href', link.url);
-    link.url = a.href;
+    a.setAttribute('href', url);
+    return a.href;
+  }
+
+  internals.nav.forEach(link => {
+    link.url = relativeToAbsolute(link.url);
+    link.subUrlBase = relativeToAbsolute(link.subUrlBase);
   });
 
   // simulate a possible change in url to initialize the

--- a/src/ui/public/utils/query_string.js
+++ b/src/ui/public/utils/query_string.js
@@ -1,3 +1,5 @@
+import { encodeQueryComponent } from '../../../utils';
+
 const qs = {};
 
 /*****
@@ -10,26 +12,6 @@ function tryDecodeURIComponent(value) {
   }
   // Ignore any invalid uri component
   catch (e) {} // eslint-disable-line no-empty
-}
-
-/**
- * This method is intended for encoding *key* or *value* parts of query component. We need a custom
- * method because encodeURIComponent is too aggressive and encodes stuff that doesn't have to be
- * encoded per http://tools.ietf.org/html/rfc3986:
- *    query         = *( pchar / "/" / "?" )
- *    pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
- *    unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
- *    pct-encoded   = "%" HEXDIG HEXDIG
- *    sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
- *                     / "*" / "+" / "," / ";" / "="
- */
-function encodeUriQuery(val, pctEncodeSpaces) {
-  return encodeURIComponent(val)
-    .replace(/%40/gi, '@')
-    .replace(/%3A/gi, ':')
-    .replace(/%24/g, '$')
-    .replace(/%2C/gi, ',')
-    .replace(/%20/g, (pctEncodeSpaces ? '%20' : '+'));
 }
 
 /**
@@ -82,7 +64,7 @@ qs.encode = function (obj) {
 };
 
 qs.param = function (key, val) {
-  return encodeUriQuery(key, true) + (val === true ? '' : '=' + encodeUriQuery(val, true));
+  return encodeQueryComponent(key, true) + (val === true ? '' : '=' + encodeQueryComponent(val, true));
 };
 
 /**

--- a/src/ui/ui_nav_link.js
+++ b/src/ui/ui_nav_link.js
@@ -1,20 +1,15 @@
-import { pick } from 'lodash';
-
 export default class UiNavLink {
   constructor(uiExports, spec) {
     this.id = spec.id;
     this.title = spec.title;
     this.order = spec.order || 0;
     this.url = `${uiExports.urlBasePath || ''}${spec.url}`;
+    this.subUrlBase = `${uiExports.urlBasePath || ''}${spec.subUrlBase || spec.url}`;
     this.description = spec.description;
     this.icon = spec.icon;
     this.linkToLastSubUrl = spec.linkToLastSubUrl === false ? false : true;
     this.hidden = spec.hidden || false;
     this.disabled = spec.disabled || false;
     this.tooltip = spec.tooltip || '';
-  }
-
-  toJSON() {
-    return pick(this, ['id', 'title', 'url', 'order', 'description', 'icon', 'linkToLastSubUrl', 'hidden', 'disabled', 'tooltip']);
   }
 }

--- a/src/utils/encode_query_component.js
+++ b/src/utils/encode_query_component.js
@@ -1,0 +1,19 @@
+/**
+ * This method is intended for encoding *key* or *value* parts of query component. We need a custom
+ * method because encodeURIComponent is too aggressive and encodes stuff that doesn't have to be
+ * encoded per http://tools.ietf.org/html/rfc3986:
+ *    query         = *( pchar / "/" / "?" )
+ *    pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+ *    unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+ *    pct-encoded   = "%" HEXDIG HEXDIG
+ *    sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
+ *                     / "*" / "+" / "," / ";" / "="
+ */
+export function encodeQueryComponent(val, pctEncodeSpaces = false) {
+  return encodeURIComponent(val)
+    .replace(/%40/gi, '@')
+    .replace(/%3A/gi, ':')
+    .replace(/%24/g, '$')
+    .replace(/%2C/gi, ',')
+    .replace(/%20/g, (pctEncodeSpaces ? '%20' : '+'));
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,6 +5,8 @@ export fromRoot from './from_root';
 export pkg from './package_json';
 export unset from './unset';
 
+export { encodeQueryComponent } from './encode_query_component';
+
 export {
   createConcatStream,
   createIntersperseStream,

--- a/src/utils/package_json.js
+++ b/src/utils/package_json.js
@@ -1,22 +1,5 @@
-import { existsSync } from 'fs';
-import { join } from 'path';
+import { dirname } from 'path';
 
-let packageDir;
-let packagePath;
-
-while (!packagePath || !existsSync(packagePath)) {
-  const prev = packageDir;
-  packageDir = prev ? join(prev, '..') : __dirname;
-  packagePath = join(packageDir, 'package.json');
-
-  if (prev === packageDir) {
-    // if going up a directory doesn't work, we
-    // are already at the root of the filesystem
-    throw new Error('unable to find package.json');
-  }
-}
-
-
-module.exports = require(packagePath);
-module.exports.__filename = packagePath;
-module.exports.__dirname = packageDir;
+module.exports = require('../../package.json');
+module.exports.__filename = require.resolve('../../package.json');
+module.exports.__dirname = dirname(module.exports.__filename);

--- a/test/server_config.js
+++ b/test/server_config.js
@@ -43,7 +43,7 @@ module.exports = {
     },
     dashboard: {
       pathname: kibanaURL,
-      hash: '/dashboard/list',
+      hash: '/dashboards',
     },
     settings: {
       pathname: kibanaURL,


### PR DESCRIPTION
I wanted to better understand why the dashboard urls needed to start with `dashboard/list` and figured out that it's because the `uiNavLink` is only designed to match urls that begin with it's url. 

This PR moves introduces an optional `subUrlBase` property to `uiNavLink` specifications that allows defining the how urls are matched to links in the nav.

This PR also moves to urls which are more similar to the urls from before 5.3:
 - `/dashboards` list of dashboard
 - `/dashboard` create a dashboard
 - `/dashboard/{id}` edit a dashboard