### PR TITLE
Design Fixes

### DIFF
--- a/src/legacy/core_plugins/embeddable_api/public/panel/_embeddable_panel.scss
+++ b/src/legacy/core_plugins/embeddable_api/public/panel/_embeddable_panel.scss
@@ -38,13 +38,22 @@
 }
 
 .embPanel__title {
-  @include euiTextTruncate;
   @include euiTitle('xxxs');
+  overflow: hidden;
   line-height: 1.5;
   flex-grow: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
 
   &:not(:empty) {
-    padding: ($euiSizeXS * 1.5) $euiSizeS 0;
+    line-height: $euiSizeL;
+    padding-left: $euiSizeS;
+  }
+
+  .embPanel__titleInner {
+    @include euiTextTruncate;
+    padding-right: $euiSizeS;
   }
 }
 

--- a/src/legacy/core_plugins/embeddable_api/public/panel/panel_header/panel_header.tsx
+++ b/src/legacy/core_plugins/embeddable_api/public/panel/panel_header/panel_header.tsx
@@ -43,6 +43,7 @@ function renderBadges(badges: Action[], embeddable: IEmbeddable) {
   return badges.map(badge => (
     <EuiBadge
       key={badge.id}
+      className="embPanel__headerBadge"
       iconType={badge.getIconType({ embeddable })}
       onClick={() => badge.execute({ embeddable })}
       onClickAriaLabel={badge.getDisplayName({ embeddable })}
@@ -100,7 +101,7 @@ function PanelHeaderUi({
           }
         )}
       >
-        {showTitle ? `${title} ` : ''}
+        {showTitle && <span className="embPanel__titleInner">{title}</span>}
         {renderBadges(badges, embeddable)}
       </div>
 

--- a/x-pack/legacy/plugins/advanced_ui_actions/public/customize_time_range_modal.tsx
+++ b/x-pack/legacy/plugins/advanced_ui_actions/public/customize_time_range_modal.tsx
@@ -130,13 +130,14 @@ export class CustomizeTimeRangeModal extends Component<CustomizeTimeRangeProps, 
           </EuiFormRow>
         </EuiModalBody>
         <EuiModalFooter>
-          <EuiFlexGroup gutterSize="s" responsive={false}>
-            <EuiFlexItem>
+          <EuiFlexGroup gutterSize="s" responsive={false} justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
               <EuiButtonEmpty
                 onClick={this.inheritFromParent}
                 color="danger"
                 data-test-subj="removePerPanelTimeRangeButton"
                 disabled={this.state.inheritTimeRange}
+                flush="left"
               >
                 {i18n.translate(
                   'xpack.advancedUiActions.customizePanelTimeRange.modal.removeButtonTitle',
@@ -146,7 +147,8 @@ export class CustomizeTimeRangeModal extends Component<CustomizeTimeRangeProps, 
                 )}
               </EuiButtonEmpty>
             </EuiFlexItem>
-            <EuiFlexItem>
+            <EuiFlexItem />
+            <EuiFlexItem grow={false}>
               <EuiButtonEmpty onClick={this.cancel} data-test-subj="cancelPerPanelTimeRangeButton">
                 {i18n.translate(
                   'xpack.advancedUiActions.customizePanelTimeRange.modal.cancelButtonTitle',
@@ -156,7 +158,7 @@ export class CustomizeTimeRangeModal extends Component<CustomizeTimeRangeProps, 
                 )}
               </EuiButtonEmpty>
             </EuiFlexItem>
-            <EuiFlexItem>
+            <EuiFlexItem grow={false}>
               <EuiButton data-test-subj="addPerPanelTimeRangeButton" onClick={this.addToPanel} fill>
                 {this.state.inheritTimeRange
                   ? i18n.translate(


### PR DESCRIPTION
- Allow panel header to wrap it’s contents (but doesn’t wrap the title)
- Fix modal footer buttons layout
